### PR TITLE
Feature :: Add latest-beta branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Git flow + GitHub PRs = <3
 ### Options
 | CLI                          | Description                                                         |
 | ---------------------------- | ------------------------------------------------------------------- |
+| `--branches.beta <value>`    | Latest beta branch                                                  |
 | `--branches.develop <value>` | Develop branch                                                      |
 | `--branches.doc <value>`     | Documentation branches prefix                                       |
 | `--branches.feature <value>` | Feature branches prefix                                             |
@@ -102,7 +103,7 @@ Start, publish or finish a hotfix.
 | `<number>` | Hotfix pull request number                   |
 
 #### Init
-Make your repository ready for `releaseman` by creating the develop branch, an initial release and labels.
+Make your repository ready for `releaseman` by creating develop and latest-beta branches, an initial release and labels.
 
 `releaseman init`
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -47,6 +47,7 @@ import runTask, { RUN_TASK } from './run-task';
 import saveState, { SAVE_STATE } from './save-state';
 import skipTask, { SKIP_TASK } from './skip-task';
 import start, { START } from './start';
+import updateBranch, { UPDATE_BRANCH } from './update-branch';
 import updatePullRequest, { UPDATE_PULL_REQUEST } from './update-pull-request';
 import updatePullRequestLabels, {
   UPDATE_PULL_REQUEST_LABELS
@@ -94,6 +95,7 @@ const actions = {
   [SAVE_STATE]: saveState,
   [SKIP_TASK]: skipTask,
   [START]: start,
+  [UPDATE_BRANCH]: updateBranch,
   [UPDATE_PULL_REQUEST]: updatePullRequest,
   [UPDATE_PULL_REQUEST_LABELS]: updatePullRequestLabels
 };
@@ -140,6 +142,7 @@ export {
   SAVE_STATE,
   SKIP_TASK,
   START,
+  UPDATE_BRANCH,
   UPDATE_PULL_REQUEST,
   UPDATE_PULL_REQUEST_LABELS
 };

--- a/src/actions/run-fix-finish.js
+++ b/src/actions/run-fix-finish.js
@@ -29,6 +29,7 @@ const runFixFinish = ({ commit, getters, state }) => {
   logActionStart(RUN_FIX_FINISH);
 
   const configError = getters.configError(
+    'branches.beta',
     'branches.develop',
     (
       state.config.isDoc
@@ -204,6 +205,16 @@ const runFixFinish = ({ commit, getters, state }) => {
       return undefined;
     })
     .then(() => getters.runOrSkip(6, 13, 14)(MERGE_BRANCHES))
+    .then(() => {
+      if (getters.isCurrentTaskIndex(14)) {
+        return commit(ASSIGN_DATA, {
+          base: state.config.branches.beta
+        })
+      }
+
+      return undefined;
+    })
+    .then(() => getters.runOrSkip(14, 15)(UPDATE_BRANCH))
     .then(() => logActionEnd(RUN_FIX_FINISH));
 };
 

--- a/src/actions/run-help.js
+++ b/src/actions/run-help.js
@@ -11,6 +11,7 @@ const runHelp = ({ state }) => {
   const options = trim(`
 Options:
 
+  --branches.beta <value>     Latest beta branch
   --branches.develop <value>  Develop branch
   --branches.doc <value>      Documentation branches prefix
   --branches.feature <value>  Feature branches prefix
@@ -158,8 +159,8 @@ Usage: releaseman init
 
 Description:
 
-  Make your repository ready for \`releaseman\` by creating the develop branch,
-  an initial release and labels.
+  Make your repository ready for \`releaseman\` by creating develop and
+  latest-beta branches, an initial release and labels.
 
 ${options}
 `);

--- a/src/actions/run-hotfix-finish.js
+++ b/src/actions/run-hotfix-finish.js
@@ -29,6 +29,7 @@ const runHotfixFinish = ({ commit, getters, state }) => {
   logActionStart(RUN_HOTFIX_FINISH);
 
   const configError = getters.configError(
+    'branches.beta',
     'branches.develop',
     (
       state.config.isDoc
@@ -240,7 +241,17 @@ const runHotfixFinish = ({ commit, getters, state }) => {
 
             return undefined;
           })
-          .then(() => getters.runOrSkip(11, 15, 16)(MERGE_BRANCHES));
+          .then(() => getters.runOrSkip(11, 15, 16)(MERGE_BRANCHES))
+          .then(() => {
+            if (getters.isCurrentTaskIndex(16)) {
+              return commit(ASSIGN_DATA, {
+                base: state.config.branches.beta
+              })
+            }
+
+            return undefined;
+          })
+          .then(() => getters.runOrSkip(16, 17)(UPDATE_BRANCH));
       }
       if (getters.isCurrentTaskIndex(10)) {
         commit(ASSIGN_DATA, {
@@ -249,7 +260,7 @@ const runHotfixFinish = ({ commit, getters, state }) => {
         });
       }
 
-      return getters.runOrSkip(10, 17)(MERGE_BRANCHES);
+      return getters.runOrSkip(10, 18)(MERGE_BRANCHES);
     })
     .then(() => logActionEnd(RUN_HOTFIX_FINISH));
 };

--- a/src/actions/run-release-start.js
+++ b/src/actions/run-release-start.js
@@ -18,6 +18,7 @@ const runReleaseStart = ({ commit, getters, state }) => {
   logActionStart(RUN_RELEASE_START);
 
   const configError = getters.configError(
+    'branches.beta',
     'branches.develop',
     'branches.master',
     'branches.release',
@@ -106,6 +107,17 @@ const runReleaseStart = ({ commit, getters, state }) => {
       return undefined;
     })
     .then(() => getters.runOrSkip(5, 6)(UPDATE_PULL_REQUEST_LABELS))
+    .then(() => {
+      if (getters.isCurrentTaskIndex(6)) {
+        return commit(ASSIGN_DATA, {
+          base: state.config.branches.beta,
+          head: state.data.branch
+        });
+      }
+
+      return undefined;
+    })
+    .then(() => getters.runOrSkip(6, 7)(UPDATE_BRANCH))
     .then(() => logActionEnd(RUN_RELEASE_START));
 };
 

--- a/src/actions/update-branch.js
+++ b/src/actions/update-branch.js
@@ -1,0 +1,23 @@
+import { ASSIGN_DATA } from '../mutations';
+import { logInfo, logTaskStart } from '../log';
+
+const UPDATE_BRANCH = 'UPDATE_BRANCH';
+
+const updateBranch = ({ commit, getters, state }, isSkipped) => {
+  logTaskStart('Update branch');
+
+  if (isSkipped) {
+    return undefined;
+  }
+
+  logInfo(`Updating \`${state.data.base}\` to \`${state.data.head}\`...`);
+
+  return getters.github.branches.update({
+    base: state.data.base,
+    head: state.data.head
+  })
+    .then(({ url }) => logInfo(url));
+};
+
+export { UPDATE_BRANCH };
+export default updateBranch;

--- a/src/config.js
+++ b/src/config.js
@@ -35,6 +35,7 @@ const Config = (argv) => {
   return {
     action: get(0)(argv._),
     branches: {
+      beta: getArgOrDefault('branches.beta'),
       develop: getArgOrDefault('branches.develop'),
       doc: getArgOrDefault('branches.doc'),
       feature: getArgOrDefault('branches.feature'),

--- a/src/defaults.json.dist
+++ b/src/defaults.json.dist
@@ -1,5 +1,6 @@
 {
   "branches": {
+    "beta": "latest-beta",
     "develop": "develop",
     "doc": "doc-",
     "feature": "f-",

--- a/src/github.js
+++ b/src/github.js
@@ -89,6 +89,13 @@ const GitHub = (config) => {
             message: commit.message,
             url: html_url
           }))
+      ),
+      update: ({ base, head }) => (
+        fetchGitHub(`git/refs/heads/${head}`)
+          .then(({ object }) => fetchGitHub(`git/refs/heads/${base}`, 'PATCH', {
+            sha: object.sha
+          }))
+          .then(() => ({ url: `${baseUrl}tree/${base}` }))
       )
     },
     commits: {


### PR DESCRIPTION
## :warning: Breaking change
The `init` script must be re-run on repositories to add the new `latest-beta` branch.

## Description
Adds a `latest-beta` branch that will have the same value as the tip of the `release` branch.
This helps in contexts where the beta is deployed for testing before being released since the deploy script can be based on a static branch name.