### PR TITLE
Feature :: Simple indexes

### DIFF
--- a/src/actions/run-changes.js
+++ b/src/actions/run-changes.js
@@ -28,14 +28,14 @@ const runChanges = ({ getters, state }) => async () => {
   let changelogHead = state.config.branches.develop
 
   if (isFinish) {
-    const latestRealease = await getters.runOrSkip(0, 1)(GET_LATEST_RELEASE)({
+    const latestRealease = await getters.runOrSkip(0)(GET_LATEST_RELEASE)({
       isPrerelease: true
     })
 
     changelogHead = latestRealease.tag
   }
 
-  await getters.runOrSkip(0, 1, 2)(GET_CHANGELOG)({
+  await getters.runOrSkip(1)(GET_CHANGELOG)({
     base: state.config.branches.master,
     head: changelogHead
   })

--- a/src/actions/run-feature-finish.js
+++ b/src/actions/run-feature-finish.js
@@ -27,30 +27,28 @@ const runFeatureFinish = ({ getters, state }) => async () => {
     'number'
   )
 
-  const pullRequest = await getters.runOrSkip(0, 1)(GET_PULL_REQUEST)({
+  const pullRequest = await getters.runOrSkip(0)(GET_PULL_REQUEST)({
     number: state.config.number
   })
 
-  if (getters.matchesTaskIndex(1)) {
-    if (!isEqual(state.config.branches.develop)(pullRequest.base)) {
-      throw `A feature cannot be merged into \`${pullRequest.base}\`!`
-    }
+  if (!isEqual(state.config.branches.develop)(pullRequest.base)) {
+    throw `A feature cannot be merged into \`${pullRequest.base}\`!`
+  }
 
-    const featureBranchesPrefix = (
-      state.config.isDoc
-        ? state.config.branches.doc
-        : state.config.branches.feature
-    )
+  const featureBranchesPrefix = (
+    state.config.isDoc
+      ? state.config.branches.doc
+      : state.config.branches.feature
+  )
 
-    if (!startsWith(featureBranchesPrefix)(pullRequest.head)) {
-      throw `A feature branch name must start with \`${
-        featureBranchesPrefix
-      }\`, your branch name is \`${pullRequest.head}\`!`
-    }
+  if (!startsWith(featureBranchesPrefix)(pullRequest.head)) {
+    throw `A feature branch name must start with \`${
+      featureBranchesPrefix
+    }\`, your branch name is \`${pullRequest.head}\`!`
   }
 
   const pullRequestLabels = (
-    await getters.runOrSkip(1, 2)(GET_PULL_REQUEST_LABELS)({
+    await getters.runOrSkip(1)(GET_PULL_REQUEST_LABELS)({
       number: state.config.number
     })
   )
@@ -61,13 +59,13 @@ const runFeatureFinish = ({ getters, state }) => async () => {
       : state.config.labels.feature
   )
 
-  if (getters.matchesTaskIndex(2, 3) && !flow(
+  if (!flow(
     map('name'),
     includes(featureLabel)
   )(pullRequestLabels)) {
     logWarn(`Missing ${featureLabel} label.\n`)
 
-    await getters.runOrSkip(2, 3)(UPDATE_PULL_REQUEST_LABELS)({
+    await getters.runOrSkip(2)(UPDATE_PULL_REQUEST_LABELS)({
       labels: flow(
         map('name'),
         concat(featureLabel)
@@ -76,14 +74,14 @@ const runFeatureFinish = ({ getters, state }) => async () => {
     })
   }
 
-  await getters.runOrSkip(2, 3, 4)(MERGE_PULL_REQUEST)({
+  await getters.runOrSkip(3)(MERGE_PULL_REQUEST)({
     isMergeable: pullRequest.isMergeable,
     isMerged: pullRequest.isMerged,
     message: `${pullRequest.name} (#${pullRequest.number})`,
     method: 'squash',
     number: state.config.number
   })
-  await getters.runOrSkip(4, 5)(DELETE_BRANCH)({
+  await getters.runOrSkip(4)(DELETE_BRANCH)({
     name: pullRequest.head
   })
 

--- a/src/actions/run-feature-publish.js
+++ b/src/actions/run-feature-publish.js
@@ -17,7 +17,7 @@ const runFeaturePublish = ({ getters, state }) => async () => {
     'name'
   )
 
-  const pullRequest = await getters.runOrSkip(0, 1)(CREATE_PULL_REQUEST)({
+  const pullRequest = await getters.runOrSkip(0)(CREATE_PULL_REQUEST)({
     base: state.config.branches.develop,
     changelog: undefined,
     head: `${
@@ -31,7 +31,7 @@ const runFeaturePublish = ({ getters, state }) => async () => {
         : 'Feature'
     } :: ${state.config.name}`
   })
-  await getters.runOrSkip(1, 2)(UPDATE_PULL_REQUEST_LABELS)({
+  await getters.runOrSkip(1)(UPDATE_PULL_REQUEST_LABELS)({
     labels: [
       (
         state.config.isDoc

--- a/src/actions/run-feature-start.js
+++ b/src/actions/run-feature-start.js
@@ -16,7 +16,7 @@ const runFeatureStart = ({ getters, state }) => async () => {
     'name'
   )
 
-  await getters.runOrSkip(0, 1)(CREATE_BRANCH)({
+  await getters.runOrSkip(0)(CREATE_BRANCH)({
     base: state.config.branches.develop,
     head: `${
       state.config.isDoc

--- a/src/actions/run-fix-publish.js
+++ b/src/actions/run-fix-publish.js
@@ -27,8 +27,8 @@ const runFixPublish = ({ getters, state }) => async () => {
     'tag'
   )
 
-  const releaseBranch = await getters.runOrSkip(0, 1)(GET_RELEASE_BRANCH)()
-  const pullRequest = await getters.runOrSkip(1, 2)(CREATE_PULL_REQUEST)({
+  const releaseBranch = await getters.runOrSkip(0)(GET_RELEASE_BRANCH)()
+  const pullRequest = await getters.runOrSkip(1)(CREATE_PULL_REQUEST)({
     base: releaseBranch.name,
     changelog: undefined,
     head: `${
@@ -42,7 +42,7 @@ const runFixPublish = ({ getters, state }) => async () => {
         : 'Fix'
     } :: ${state.config.name}`
   })
-  await getters.runOrSkip(2, 3)(UPDATE_PULL_REQUEST_LABELS)({
+  await getters.runOrSkip(2)(UPDATE_PULL_REQUEST_LABELS)({
     labels: [
       (
         state.config.isDoc

--- a/src/actions/run-fix-start.js
+++ b/src/actions/run-fix-start.js
@@ -17,8 +17,8 @@ const runFixStart = ({ getters, state }) => async () => {
     'tag'
   )
 
-  const releaseBranch = await getters.runOrSkip(0, 1)(GET_RELEASE_BRANCH)()
-  await getters.runOrSkip(1, 2)(CREATE_BRANCH)({
+  const releaseBranch = await getters.runOrSkip(0)(GET_RELEASE_BRANCH)()
+  await getters.runOrSkip(1)(CREATE_BRANCH)({
     base: releaseBranch.name,
     head: `${
       state.config.isDoc

--- a/src/actions/run-hotfix-publish.js
+++ b/src/actions/run-hotfix-publish.js
@@ -22,7 +22,7 @@ const runHotfixPublish = ({ getters, state }) => async () => {
     'name'
   )
 
-  const pullRequest = await getters.runOrSkip(0, 1)(CREATE_PULL_REQUEST)({
+  const pullRequest = await getters.runOrSkip(0)(CREATE_PULL_REQUEST)({
     base: state.config.branches.master,
     changelog: undefined,
     head: `${
@@ -36,7 +36,7 @@ const runHotfixPublish = ({ getters, state }) => async () => {
         : 'Hotfix'
     } :: ${state.config.name}`
   })
-  await getters.runOrSkip(1, 2)(UPDATE_PULL_REQUEST_LABELS)({
+  await getters.runOrSkip(1)(UPDATE_PULL_REQUEST_LABELS)({
     labels: [
       (
         state.config.isDoc

--- a/src/actions/run-hotfix-start.js
+++ b/src/actions/run-hotfix-start.js
@@ -16,7 +16,7 @@ const runHotfixStart = ({ getters, state }) => async () => {
     'name'
   )
 
-  await getters.runOrSkip(0, 1)(CREATE_BRANCH)({
+  await getters.runOrSkip(0)(CREATE_BRANCH)({
     base: state.config.branches.master,
     head: `${
       state.config.isDoc

--- a/src/actions/run-init.js
+++ b/src/actions/run-init.js
@@ -42,29 +42,27 @@ const runInit = ({ getters, state }) => async () => {
     'tag'
   )
 
-  const isDevelopPresent = await getters.runOrSkip(0, 1)(GET_BRANCH_EXISTENCE)({
+  const isDevelopPresent = await getters.runOrSkip(0)(GET_BRANCH_EXISTENCE)({
     name: state.config.branches.develop
   })
 
   if (isDevelopPresent) {
     logWarn(`${state.config.branches.develop} already present.\n`)
   } else {
-    await getters.runOrSkip(1, 2)(CREATE_BRANCH)({
+    await getters.runOrSkip(1)(CREATE_BRANCH)({
       base: state.config.branches.master,
       head: state.config.branches.develop
     })
   }
 
-  const isReleasesPresent = (
-    await getters.runOrSkip(1, 2, 3)(GET_RELEASES_EXISTENCE)({
-      isPrerelease: false
-    })
-  )
+  const isReleasesPresent = await getters.runOrSkip(2)(GET_RELEASES_EXISTENCE)({
+    isPrerelease: false
+  })
 
   if (isReleasesPresent) {
     logWarn('Release already present.\n')
   } else {
-    await getters.runOrSkip(3, 4)(CREATE_RELEASE)({
+    await getters.runOrSkip(3)(CREATE_RELEASE)({
       branch: state.config.branches.master,
       changelog: 'Initial release',
       isPrerelease: false,
@@ -74,7 +72,7 @@ const runInit = ({ getters, state }) => async () => {
   }
 
   const isPrereleasesPresent = (
-    await getters.runOrSkip(3, 4, 5)(GET_RELEASES_EXISTENCE)({
+    await getters.runOrSkip(4)(GET_RELEASES_EXISTENCE)({
       isPrerelease: true
     })
   )
@@ -82,11 +80,11 @@ const runInit = ({ getters, state }) => async () => {
   if (isPrereleasesPresent) {
     logWarn('Prerelease already present.\n')
   } else {
-    const latestRelease = await getters.runOrSkip(5, 6)(GET_LATEST_RELEASE)({
+    const latestRelease = await getters.runOrSkip(5)(GET_LATEST_RELEASE)({
       isPrerelease: false
     })
 
-    await getters.runOrSkip(6, 7)(CREATE_RELEASE)({
+    await getters.runOrSkip(6)(CREATE_RELEASE)({
       branch: state.config.branches.master,
       changelog: `${latestRelease.name} beta`,
       isPrerelease: true,
@@ -95,23 +93,21 @@ const runInit = ({ getters, state }) => async () => {
     })
   }
 
-  const isBranchPresent = (
-    await getters.runOrSkip(5, 7, 8)(GET_BRANCH_EXISTENCE)({
-      name: state.config.branches.beta
-    })
-  )
+  const isBranchPresent = await getters.runOrSkip(7)(GET_BRANCH_EXISTENCE)({
+    name: state.config.branches.beta
+  })
 
   if (isBranchPresent) {
     logWarn(`${state.config.branches.beta} already present.\n`)
   } else {
-    await getters.runOrSkip(8, 9)(CREATE_BRANCH)({
+    await getters.runOrSkip(8)(CREATE_BRANCH)({
       base: state.config.branches.master,
       head: state.config.branches.beta
     })
   }
 
   const labelsNames = map('name')(
-    await getters.runOrSkip(8, 9, 10)(GET_LABELS)()
+    await getters.runOrSkip(9)(GET_LABELS)()
   )
 
   const missingLabels = flow(
@@ -126,7 +122,7 @@ const runInit = ({ getters, state }) => async () => {
   if (isEmpty(missingLabels)) {
     logWarn('All mandatory labels already present.\n')
   } else {
-    await getters.runOrSkip(10, 11)(CREATE_LABELS)({
+    await getters.runOrSkip(10)(CREATE_LABELS)({
       labels: missingLabels
     })
   }

--- a/src/actions/run-release-finish.js
+++ b/src/actions/run-release-finish.js
@@ -28,7 +28,7 @@ const runReleaseFinish = ({ getters, state }) => async () => {
     'tag'
   )
 
-  const nextRelease = await getters.runOrSkip(0, 1)(GET_NEXT_RELEASE)({
+  const nextRelease = await getters.runOrSkip(0)(GET_NEXT_RELEASE)({
     isBreaking: false,
     isFix: false,
     isPrerelease: false
@@ -41,35 +41,35 @@ const runReleaseFinish = ({ getters, state }) => async () => {
 
   const branch = `${state.config.branches.release}${version}`
 
-  const changelog = await getters.runOrSkip(1, 2)(GET_CHANGELOG)({
+  const changelog = await getters.runOrSkip(1)(GET_CHANGELOG)({
     base: state.config.branches.master,
     head: branch
   })
-  const pullRequest = await getters.runOrSkip(2, 3)(FIND_PULL_REQUEST)({
+  const pullRequest = await getters.runOrSkip(2)(FIND_PULL_REQUEST)({
     base: state.config.branches.master,
     head: branch
   })
 
   const pullRequestName = `Release :: ${nextRelease.name}`
 
-  await getters.runOrSkip(3, 4)(UPDATE_PULL_REQUEST)({
+  await getters.runOrSkip(3)(UPDATE_PULL_REQUEST)({
     changelog: changelog.text,
     name: pullRequestName,
     number: pullRequest.number
   })
   const pullRequestLabels = (
-    await getters.runOrSkip(4, 5)(GET_PULL_REQUEST_LABELS)({
+    await getters.runOrSkip(4)(GET_PULL_REQUEST_LABELS)({
       number: pullRequest.number
     })
   )
 
-  if (getters.matchesTaskIndex(5, 6) && !flow(
+  if (!flow(
     map('name'),
     includes(state.config.labels.release)
   )(pullRequestLabels)) {
     logWarn(`Missing ${state.config.labels.release} label.\n`)
 
-    await getters.runOrSkip(5, 6)(UPDATE_PULL_REQUEST_LABELS)({
+    await getters.runOrSkip(5)(UPDATE_PULL_REQUEST_LABELS)({
       labels: flow(
         map('name'),
         concat(state.config.labels.release)
@@ -78,17 +78,17 @@ const runReleaseFinish = ({ getters, state }) => async () => {
     })
   }
 
-  await getters.runOrSkip(5, 6, 7)(MERGE_PULL_REQUEST)({
+  await getters.runOrSkip(6)(MERGE_PULL_REQUEST)({
     isMergeable: pullRequest.isMergeable,
     isMerged: pullRequest.isMerged,
     message: `${pullRequestName} (#${pullRequest.number})`,
     method: undefined,
     number: pullRequest.number
   })
-  await getters.runOrSkip(7, 8)(DELETE_BRANCH)({
+  await getters.runOrSkip(7)(DELETE_BRANCH)({
     name: branch
   })
-  await getters.runOrSkip(8, 9)(CREATE_RELEASE)({
+  await getters.runOrSkip(8)(CREATE_RELEASE)({
     branch: state.config.branches.master,
     changelog: changelog.text,
     isPrerelease: false,

--- a/src/actions/run-release-start.js
+++ b/src/actions/run-release-start.js
@@ -31,11 +31,11 @@ const runReleaseStart = ({ getters, state }) => async () => {
     throw 'The <name> param must be the final release name (no beta)!'
   }
 
-  const changelog = await getters.runOrSkip(0, 1)(GET_CHANGELOG)({
+  const changelog = await getters.runOrSkip(0)(GET_CHANGELOG)({
     base: state.config.branches.master,
     head: state.config.branches.develop
   })
-  const nextPrerelease = await getters.runOrSkip(1, 2)(GET_NEXT_RELEASE)({
+  const nextPrerelease = await getters.runOrSkip(1)(GET_NEXT_RELEASE)({
     isBreaking: includes(state.config.labels.breaking)(
       changelog.labels
     ),
@@ -50,18 +50,18 @@ const runReleaseStart = ({ getters, state }) => async () => {
 
   const branch = `${state.config.branches.release}${version}`
 
-  await getters.runOrSkip(2, 3)(CREATE_BRANCH)({
+  await getters.runOrSkip(2)(CREATE_BRANCH)({
     base: state.config.branches.develop,
     head: branch
   })
-  await getters.runOrSkip(3, 4)(CREATE_RELEASE)({
+  await getters.runOrSkip(3)(CREATE_RELEASE)({
     branch: branch,
     changelog: changelog.text,
     isPrerelease: true,
     name: nextPrerelease.name,
     tag: nextPrerelease.tag
   })
-  const pullRequest = await getters.runOrSkip(4, 5)(CREATE_PULL_REQUEST)({
+  const pullRequest = await getters.runOrSkip(4)(CREATE_PULL_REQUEST)({
     base: state.config.branches.master,
     changelog: changelog.text,
     head: branch,
@@ -69,11 +69,11 @@ const runReleaseStart = ({ getters, state }) => async () => {
       new RegExp('^(.*?) beta$').exec(nextPrerelease.name)
     )}`
   })
-  await getters.runOrSkip(5, 6)(UPDATE_PULL_REQUEST_LABELS)({
+  await getters.runOrSkip(5)(UPDATE_PULL_REQUEST_LABELS)({
     labels: [state.config.labels.release],
     number: pullRequest.number
   })
-  await getters.runOrSkip(6, 7)(UPDATE_BRANCH)({
+  await getters.runOrSkip(6)(UPDATE_BRANCH)({
     base: state.config.branches.beta,
     head: branch
   })

--- a/src/store.js
+++ b/src/store.js
@@ -2,11 +2,10 @@ import actions, { RUN_TASK, SKIP_TASK } from './actions'
 import filter from 'lodash/fp/filter'
 import flow from 'lodash/fp/flow'
 import get from 'lodash/fp/get'
-import includes from 'lodash/fp/includes'
+import gte from 'lodash/fp/gte'
 import isEmpty from 'lodash/fp/isEmpty'
 import isUndefined from 'lodash/fp/isUndefined'
 import join from 'lodash/fp/join'
-import last from 'lodash/fp/last'
 import map from 'lodash/fp/map'
 import mutations from './mutations'
 
@@ -32,15 +31,14 @@ const Store = {
   ),
   getters: {
     github: null,
-    matchesTaskIndex: (...indexes) => includes(Store.state.taskIndex)(indexes),
     query: (path) => (payload) => get(path)(Store.getters.github)(payload),
-    runOrSkip: (...indexes) => (action) => (payload) => Store.dispatch((
-      Store.getters.matchesTaskIndex(...indexes)
+    runOrSkip: (index) => (action) => (payload) => Store.dispatch((
+      gte(index)(Store.state.taskIndex)
         ? RUN_TASK
         : SKIP_TASK
     ))({
       action: action,
-      index: last(indexes),
+      index: index,
       payload: payload
     }),
     validateConfig: (...keys) => {
@@ -61,7 +59,7 @@ const Store = {
   state: {
     config: {},
     data: {},
-    taskIndex: 0
+    taskIndex: -1
   }
 }
 


### PR DESCRIPTION
## Description
Reduces the risk of typos & errors while using `runOrSkip` by only passing the `index` of the task that should be run or skipped and checking if it's greater than or equal to the `state`'s `taskIndex`